### PR TITLE
Split event capture from submission

### DIFF
--- a/src/app/SharpRaven/Data/Requester.cs
+++ b/src/app/SharpRaven/Data/Requester.cs
@@ -67,7 +67,7 @@ namespace SharpRaven.Data
                 throw new ArgumentNullException("ravenClient");
 
             this.ravenClient = ravenClient;
-            this.packet = ravenClient.PreparePacket(packet);
+            this.packet = packet;
             this.data = new RequestData(this);
 
 			this.webRequest = CreateWebRequest(ravenClient.CurrentDsn.SentryUri);

--- a/src/app/SharpRaven/IRavenClient.cs
+++ b/src/app/SharpRaven/IRavenClient.cs
@@ -121,6 +121,13 @@ namespace SharpRaven
         string Capture(SentryEvent @event);
 
 
+        /// <summary>Prepares the specified <paramref name="event"/> but does not send it to sentry</summary>
+        /// <param name="event">The event to prepare.</param>
+        /// <returns>
+        /// The <see cref="JsonPacket" /> of the prepared event.
+        /// </returns>
+        JsonPacket BuildPacket(SentryEvent @event);
+
         /// <summary>
         /// Captures the <see cref="Exception" />.
         /// </summary>

--- a/src/app/SharpRaven/NoOpRavenClient.cs
+++ b/src/app/SharpRaven/NoOpRavenClient.cs
@@ -157,6 +157,12 @@ namespace SharpRaven
         }
 
 
+        public JsonPacket BuildPacket(SentryEvent @event)
+        {
+            return new JsonPacket("");
+        }
+
+
         /// <summary>
         /// Captures the event.
         /// </summary>

--- a/src/app/SharpRaven/RavenClient.Net45.cs
+++ b/src/app/SharpRaven/RavenClient.Net45.cs
@@ -55,15 +55,9 @@ namespace SharpRaven
         /// </returns>
         public async Task<string> CaptureAsync(SentryEvent @event)
         {
-            @event.Tags = MergeTags(@event.Tags);
-            if (!this.breadcrumbs.IsEmpty())
-                @event.Breadcrumbs = this.breadcrumbs.ToList();
-            
-            var packet = this.jsonPacketFactory.Create(CurrentDsn.ProjectID, @event);
-
+            var packet = BuildPacket(@event);
             var eventId = await SendAsync(packet);
-            RestartTrails();
-
+            
             return eventId;
         }
 
@@ -136,7 +130,7 @@ namespace SharpRaven
         /// <returns>
         /// The <see cref="JsonPacket.EventID" /> of the successfully captured JSON packet, or <c>null</c> if it fails.
         /// </returns>
-        protected virtual async Task<string> SendAsync(JsonPacket packet)
+        public virtual async Task<string> SendAsync(JsonPacket packet)
         {
             Requester requester = null;
 

--- a/src/app/SharpRaven/RavenClient.cs
+++ b/src/app/SharpRaven/RavenClient.cs
@@ -214,6 +214,16 @@ namespace SharpRaven
         /// </returns>
         public string Capture(SentryEvent @event)
         {
+            var packet = BuildPacket(@event);
+
+            var eventId = Send(packet);
+            
+            return eventId;
+        }
+
+
+        public JsonPacket BuildPacket(SentryEvent @event)
+        {
             if (@event == null)
                 throw new ArgumentNullException("event");
 
@@ -223,12 +233,12 @@ namespace SharpRaven
 
             var packet = this.jsonPacketFactory.Create(CurrentDsn.ProjectID, @event);
 
-            var eventId = Send(packet);
+            packet = PreparePacket(packet);
+
             RestartTrails();
 
-            return eventId;
+            return packet;
         }
-
 
 
         /// <summary>
@@ -349,7 +359,7 @@ namespace SharpRaven
         /// <returns>
         /// The <see cref="JsonPacket.EventID" /> of the successfully captured JSON packet, or <c>null</c> if it fails.
         /// </returns>
-        protected virtual string Send(JsonPacket packet)
+        public virtual string Send(JsonPacket packet)
         {
             Requester requester = null;
 

--- a/src/tests/SharpRaven.Nancy.UnitTests/NancyTests.cs
+++ b/src/tests/SharpRaven.Nancy.UnitTests/NancyTests.cs
@@ -180,7 +180,7 @@ namespace SharpRaven.Nancy.UnitTests
             }
 
 
-            protected override string Send(JsonPacket packet)
+            public override string Send(JsonPacket packet)
             {
                 if (this.dsn != null)
                     return this.dsn.ToString();

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/BreadcrumbsRavenClientTests.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/BreadcrumbsRavenClientTests.cs
@@ -44,6 +44,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
             var breadcrumbsRecord = new Breadcrumb("foo");
 
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
 
@@ -58,6 +59,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
         [Test]
         public void Should_Call_JsonFactory_to_Breadcrumbs_Null_When_NotUsed() {
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
 
@@ -70,6 +72,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
         [Test]
         public void Should_Call_JsonFactory_to_Breadcrumbs_Null_When_Not_Informed() {
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
 
@@ -84,6 +87,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
         [Test]
         public void Should_RestartTrails_When_Call_ResetTrails() {
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
 
@@ -99,6 +103,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
         [Test]
         public void Shouldnot_Register_Trails_When_IgnoreBreadcrumb() {
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
             ravenClient.IgnoreBreadcrumbs = true;
@@ -117,6 +122,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
             var breadcrumbsRecord = new Breadcrumb("foo");
 
             var jsonPacketFactory = Substitute.For<IJsonPacketFactory>();
+            jsonPacketFactory.Create(null, null).ReturnsForAnyArgs(new JsonPacket(""));
 
             IRavenClient ravenClient = new RavenClientTestable(TestHelper.DsnUri, jsonPacketFactory);
 
@@ -138,7 +144,7 @@ namespace SharpRaven.UnitTests.RavenClientTests {
 
             }
 
-            protected override string Send(JsonPacket packet) {
+            public override string Send(JsonPacket packet) {
                 return null;
             }
         }

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureRequestTests.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureRequestTests.cs
@@ -1,0 +1,80 @@
+﻿#region License
+
+// Copyright (c) 2014 The Sentry Team and individual contributors.
+// All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification, are permitted
+// provided that the following conditions are met:
+// 
+//     1. Redistributions of source code must retain the above copyright notice, this list of
+//        conditions and the following disclaimer.
+// 
+//     2. Redistributions in binary form must reproduce the above copyright notice, this list of
+//        conditions and the following disclaimer in the documentation and/or other materials
+//        provided with the distribution.
+// 
+//     3. Neither the name of the Sentry nor the names of its contributors may be used to
+//        endorse or promote products derived from this software without specific prior written
+//        permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR
+// IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+// WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+// ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#endregion
+
+using NSubstitute;
+
+using NUnit.Framework;
+
+using SharpRaven.Data;
+
+namespace SharpRaven.UnitTests.RavenClientTests
+{
+    [TestFixture]
+    public class CaptureRequestTests
+    {
+        #region SetUp/Teardown
+
+        [SetUp]
+        public void SetUp()
+        {
+            this.tester = new CaptureTester();
+        }
+
+        #endregion
+
+        [Test]
+        public void BuildPacket_CapturesRequestUrlAndUser()
+        {
+            var request = new SentryRequest
+            {
+                Url = "/foo/bar"
+            };
+
+            var requestFactory = Substitute.For<ISentryRequestFactory>();
+            requestFactory.Create().Returns(request);
+
+            var user = new SentryUser("user@email.com");
+            var userFactory = Substitute.For<ISentryUserFactory>();
+            userFactory.Create().Returns(user);
+
+            var client = this.tester.GetTestableRavenClient("", requestFactory, userFactory);
+            var packet = client.BuildPacket(new SentryEvent(new SentryMessage("some message")));
+            
+            Assert.IsNotNull(packet, "the packet should not be null");
+            Assert.IsNotNull(packet.Request, "the request should not be null");
+            Assert.AreEqual("/foo/bar", packet.Request.Url);
+
+            Assert.IsNotNull(packet.User, "user should not be null");
+            Assert.AreEqual("user@email.com", packet.User.Username);
+        }
+
+        private CaptureTester tester;
+    }
+}

--- a/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureTester.cs
+++ b/src/tests/SharpRaven.UnitTests/RavenClientTests/CaptureTester.cs
@@ -144,10 +144,10 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
 
         [Ignore]
-        public IRavenClient GetTestableRavenClient(string project)
+        public IRavenClient GetTestableRavenClient(string project, ISentryRequestFactory requestFactory = null, ISentryUserFactory userFactory = null)
         {
             var jsonPacketFactory = new TestableJsonPacketFactory(project);
-            return new TestableRavenClient(dsnUri, jsonPacketFactory);
+            return new TestableRavenClient(dsnUri, jsonPacketFactory, requestFactory, userFactory);
         }
 
 
@@ -311,8 +311,8 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
         private class TestableRavenClient : RavenClient
         {
-            public TestableRavenClient(string dsn, IJsonPacketFactory jsonPacketFactory = null)
-                : base(dsn, jsonPacketFactory)
+            public TestableRavenClient(string dsn, IJsonPacketFactory jsonPacketFactory = null, ISentryRequestFactory requestFactory = null, ISentryUserFactory userFactory = null)
+                : base(dsn, jsonPacketFactory, requestFactory, userFactory)
             {
             }
 
@@ -320,7 +320,7 @@ namespace SharpRaven.UnitTests.RavenClientTests
             public JsonPacket LastPacket { get; private set; }
 
 
-            protected override string Send(JsonPacket packet)
+            public override string Send(JsonPacket packet)
             {
                 // TODO(dcramer): this is duped from RavenClient
                 packet = PreparePacket(packet);
@@ -330,7 +330,7 @@ namespace SharpRaven.UnitTests.RavenClientTests
 
 
 #if (!net40) && (!net35)
-            protected override Task<string> SendAsync(JsonPacket packet)
+            public override Task<string> SendAsync(JsonPacket packet)
             {
                 packet = PreparePacket(packet);
                 LastPacket = packet;


### PR DESCRIPTION
Additional details https://github.com/getsentry/raven-csharp/issues/239

Split the creation of the packet and the submission of the event to sentry so the request thread does not need to be the one to send the event but we can still capture the request and user level details. This allows us to capture the event on the request thread but submit it on a background thread

@eugene-yao-zocdoc 